### PR TITLE
(借助ai)Extract camera/uart abstraction into separate files with minimal core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,73 +2,79 @@ cmake_minimum_required(VERSION 3.10)
 
 project(icar)
 
+option(ENABLE_X86_MOCK "Enable x86 mock camera/uart" OFF)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-O3 -Wall -mcpu=native -flto -pthread -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(INCLUDE_PATH "/usr/local/include")
-set(LIB_PATH "/usr/local/lib")
 
 find_package(PkgConfig)
 pkg_search_module(GLIB REQUIRED glib-2.0)
 include_directories(${GLIB_INCLUDE_DIRS})
 
-pkg_search_module(SERIAL REQUIRED libserial)
-include_directories(${SERIAL_INCLUDE_DIRS})
-link_directories(${SERIAL_LIBRARY_DIRS})
-
 find_package(OpenCV REQUIRED)
 
-# find ppnc
 pkg_search_module(PPNC REQUIRED ppnc)
 include_directories(${PPNC_INCLUDE_DIRS})
 link_directories(${PPNC_LIBRARY_DIRS})
 
-
-# find onnx
 pkg_search_module(ONNX REQUIRED onnx)
 include_directories(${ONNX_INCLUDE_DIRS})
 link_directories(${ONNX_LIBRARY_DIRS})
 
+if(NOT ENABLE_X86_MOCK)
+    pkg_search_module(SERIAL REQUIRED libserial)
+    include_directories(${SERIAL_INCLUDE_DIRS})
+    link_directories(${SERIAL_LIBRARY_DIRS})
+endif()
+
 add_executable(icar main.cpp
-	param/param.hpp
-	capture/capture.h
-	capture/capture.cpp
-	thread/thread.h
-	thread/thread.cpp
-	include/common.hpp
-	include/detection.hpp
-	include/json.hpp
-	include/uart.hpp
-	include/logger.hpp
-	track/imgprocess/imgprocess.h
-	track/imgprocess/imgprocess.cpp
-	track/standard/standard.h
-	track/standard/standard.cpp
-	track/standard/general.h
-	track/basic/ring.cpp
-	track/basic/ring.h
-	track/basic/cross.cpp
-	track/basic/cross.h
-	track/special/catering.h
-	track/special/catering.cpp
-	track/special/obstacle.h
-	track/special/obstacle.cpp
-	track/special/layby.h
-	track/special/layby.cpp
-	track/special/bridge.h
-	track/special/bridge.cpp
-	track/special/charging.h
-	track/special/charging.cpp
-	track/special/crosswalk.h
-	track/special/crosswalk.cpp
-	)
-
-
-target_link_libraries(icar
-	${OpenCV_LIBRARIES}
-	${PPNC_LIBRARIES}
-	${ONNX_LIBRARIES}
-	pthread
-	${SERIAL_LDFLAGS}
+    param/param.hpp
+    capture/capture.h
+    capture/capture.cpp
+    thread/thread.h
+    thread/thread.cpp
+    include/common.hpp
+    include/detection.hpp
+    include/json.hpp
+    include/uart.hpp
+    include/hw_interface.hpp
+    hardware/hw_factory.cpp
+    include/logger.hpp
+    track/imgprocess/imgprocess.h
+    track/imgprocess/imgprocess.cpp
+    track/standard/standard.h
+    track/standard/standard.cpp
+    track/standard/general.h
+    track/basic/ring.cpp
+    track/basic/ring.h
+    track/basic/cross.cpp
+    track/basic/cross.h
+    track/special/catering.h
+    track/special/catering.cpp
+    track/special/obstacle.h
+    track/special/obstacle.cpp
+    track/special/layby.h
+    track/special/layby.cpp
+    track/special/bridge.h
+    track/special/bridge.cpp
+    track/special/charging.h
+    track/special/charging.cpp
+    track/special/crosswalk.h
+    track/special/crosswalk.cpp
 )
 
+if(ENABLE_X86_MOCK)
+    target_compile_definitions(icar PRIVATE ENABLE_X86_MOCK)
+endif()
+
+target_link_libraries(icar
+    ${OpenCV_LIBRARIES}
+    ${PPNC_LIBRARIES}
+    ${ONNX_LIBRARIES}
+    pthread
+)
+
+if(NOT ENABLE_X86_MOCK)
+    target_link_libraries(icar ${SERIAL_LDFLAGS})
+endif()

--- a/ci/run_ci_x86_mock.sh
+++ b/ci/run_ci_x86_mock.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/build-x86-mock"
+
+cmake -S "${ROOT_DIR}" -B "${BUILD_DIR}" -DENABLE_X86_MOCK=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build "${BUILD_DIR}" -j"$(nproc)"
+
+echo "x86 mock build passed."

--- a/hardware/hw_factory.cpp
+++ b/hardware/hw_factory.cpp
@@ -1,0 +1,66 @@
+#include "../include/hw_interface.hpp"
+#include <iostream>
+
+#ifndef ENABLE_X86_MOCK
+#include "../capture/capture.h"
+#include "../include/uart.hpp"
+
+class CameraAdapter : public ICamera {
+public:
+    explicit CameraAdapter(const Config &config) : capture_(config) {}
+    bool getImage(cv::Mat &img) override { return capture_.getImage(img); }
+private:
+    Capture capture_;
+};
+
+class UartAdapter : public IUart {
+public:
+    explicit UartAdapter(const std::string &portName) : uart_(portName) {}
+    int open() override { return uart_.open(); }
+    void carControl(float speed, uint16_t servo, uint16_t flag) override { uart_.carControl(speed, servo, flag); }
+private:
+    Uart uart_;
+};
+#else
+class MockCamera : public ICamera {
+public:
+    explicit MockCamera(const Config &) {}
+    bool getImage(cv::Mat &img) override {
+        static int tick = 0;
+        img = cv::Mat::zeros(240, 320, CV_8UC3);
+        cv::line(img, cv::Point(tick % 320, 0), cv::Point(tick % 320, 239), cv::Scalar(0, 255, 0), 2);
+        cv::putText(img, "x86 mock camera", cv::Point(40, 120), cv::FONT_HERSHEY_SIMPLEX, 0.6, cv::Scalar(255, 255, 255), 1);
+        ++tick;
+        return true;
+    }
+};
+
+class MockUart : public IUart {
+public:
+    explicit MockUart(const std::string &portName) : portName_(portName) {}
+    int open() override { std::cout << "[MOCK UART] open " << portName_ << std::endl; return 0; }
+    void carControl(float speed, uint16_t servo, uint16_t flag) override {
+        std::cout << "[MOCK UART] speed=" << speed << " servo=" << servo << " flag=" << flag << std::endl;
+    }
+private:
+    std::string portName_;
+};
+#endif
+
+std::shared_ptr<ICamera> createCamera(const Config &config)
+{
+#ifndef ENABLE_X86_MOCK
+    return std::make_shared<CameraAdapter>(config);
+#else
+    return std::make_shared<MockCamera>(config);
+#endif
+}
+
+std::shared_ptr<IUart> createUart(const std::string &portName)
+{
+#ifndef ENABLE_X86_MOCK
+    return std::make_shared<UartAdapter>(portName);
+#else
+    return std::make_shared<MockUart>(portName);
+#endif
+}

--- a/include/hw_interface.hpp
+++ b/include/hw_interface.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <opencv2/opencv.hpp>
+#include "../param/param.hpp"
+
+class ICamera {
+public:
+    virtual ~ICamera() = default;
+    virtual bool getImage(cv::Mat &img) = 0;
+};
+
+class IUart {
+public:
+    virtual ~IUart() = default;
+    virtual int open() = 0;
+    virtual void carControl(float speed, uint16_t servo, uint16_t flag) = 0;
+};
+
+std::shared_ptr<ICamera> createCamera(const Config &config);
+std::shared_ptr<IUart> createUart(const std::string &portName);

--- a/main.cpp
+++ b/main.cpp
@@ -64,8 +64,6 @@
 
 
 
-Uart uart = Uart("/dev/ttyUSB0"); // 初始化串口驱动
-
 void Set_Config(Config &config)
 {
     Config cfg_pth;
@@ -118,17 +116,17 @@ int main()
     Config config;
     Set_Config(config);
 
-    shared_ptr<Uart> uart;
+    shared_ptr<IUart> uart;
     if (config.ttyUsb == 0)
-        uart = make_shared<Uart>("/dev/ttyUSB0"); // 初始化串口驱动
+        uart = createUart("/dev/ttyUSB0"); // 初始化串口驱动
     else if (config.ttyUsb == 1)
-        uart = make_shared<Uart>("/dev/ttyUSB1");
+        uart = createUart("/dev/ttyUSB1");
     else if (config.ttyUsb == 2)
-        uart = make_shared<Uart>("/dev/ttyUSB2");
+        uart = createUart("/dev/ttyUSB2");
     else if (config.ttyUsb == 3)
-        uart = make_shared<Uart>("/dev/ttyUSB3");
+        uart = createUart("/dev/ttyUSB3");
     else if (config.ttyUsb == 4)
-        uart = make_shared<Uart>("/dev/ttyUSB4");
+        uart = createUart("/dev/ttyUSB4");
     int ret = uart->open();
     if (ret != 0)
     {
@@ -151,7 +149,8 @@ int main()
     }
     std::vector<PredictResult> predict_result;
 
-    std::thread task_producer(&producer, std::ref(task_factory), std::ref(AI_task_factory), std::ref(config));
+    auto camera = createCamera(config);
+    std::thread task_producer(&producer, std::ref(task_factory), std::ref(AI_task_factory), std::ref(camera));
 
 	std::thread AI_producer(&AIConsumer, std::ref(AI_task_factory), std::ref(predict_result), std::ref(config));
 

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -12,7 +12,6 @@
 
 using namespace cv;
 
-extern Uart uart;
 bool flag = false;
 float pitch_angle;
 General general;
@@ -29,13 +28,12 @@ void callbackSignal(int signum)
 	cout << "====System Exit!!!  -->  CarStopping! " << signum << endl;
 }
 
-bool producer(Factory<TaskData> & task_data, Factory<TaskData> & AI_task_data, Config & config) {
-	Capture capture(config);
+bool producer(Factory<TaskData> & task_data, Factory<TaskData> & AI_task_data, std::shared_ptr<ICamera> &camera) {
     
 
 	while (true) {
 		TaskData src;
-		if (!capture.getImage(src.img)) 
+		if (!camera->getImage(src.img)) 
         {
             printf("noimage");
             continue;
@@ -101,7 +99,7 @@ bool AIConsumer(Factory<TaskData> & AI_task_data, std::vector<PredictResult> & p
 	return true;	
 }
 
-bool consumer(Factory<TaskData> & task_data, Factory<DebugData> & debug_data, std::vector<PredictResult> & predict_result, Config & config, shared_ptr<Uart> & uart) {
+bool consumer(Factory<TaskData> & task_data, Factory<DebugData> & debug_data, std::vector<PredictResult> & predict_result, Config & config, shared_ptr<IUart> & uart) {
 	// 此代码为开源代码
     Standard standard(config);
     bool stop2_flag = false;
@@ -194,7 +192,7 @@ bool debugDataConsumer(Factory<DebugData> & debug_data) {
 	return true;
 }
 
-bool uartReceive(std::shared_ptr<Uart> & uart)
+bool uartReceive(std::shared_ptr<IUart> & uart)
 {
     while(true){
         // uart->receiveCheck();

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -14,10 +14,10 @@
 
 #include "../include/detection.hpp"
 #include "../param/param.hpp"
+#include "../include/hw_interface.hpp"
 #include "../capture/capture.h"
 #include "../track/standard/standard.h"
 // #include "../port/canPort.hpp"
-#include "../include/uart.hpp"
 #include "../track/special/catering.h"
 
 struct DebugData{
@@ -72,11 +72,11 @@ bool Factory<T>::consume(T &product) {
 }
 // ------------------------------------ //
 
-bool producer(Factory<TaskData> & task_data, Factory<TaskData> & AI_task_data, Config & config);
+bool producer(Factory<TaskData> & task_data, Factory<TaskData> & AI_task_data, std::shared_ptr<ICamera> &camera);
 bool AIConsumer(Factory<TaskData> & task_data, std::vector<PredictResult> & predict_result, Config & config);
-bool consumer(Factory<TaskData> & task_data, Factory<DebugData> & debug_data, std::vector<PredictResult> & predict_result, Config & config, std::shared_ptr<Uart> & uart);
+bool consumer(Factory<TaskData> & task_data, Factory<DebugData> & debug_data, std::vector<PredictResult> & predict_result, Config & config, std::shared_ptr<IUart> & uart);
 void drawBox(Mat &img, std::vector<PredictResult> results);
 bool debugDataConsumer(Factory<DebugData> & debug_data);
-bool uartReceive(std::shared_ptr<Uart> & uart);
+bool uartReceive(std::shared_ptr<IUart> & uart);
 
 cv::Scalar getCvcolor(int index);


### PR DESCRIPTION

<img width="1220" height="633" alt="Screenshot_2026-05-11-10-11-09-086_org mozilla firefox_1778468451678edit" src="https://github.com/user-attachments/assets/058a2ae0-3dc6-4ce0-a74b-e09b19f8bc96" />
(此补丁未充分验证,仅提供想法参考)这或许是很糟糕的点子,不太懂竞赛,也不知道现实工程里是怎么样的,只是有这个小想法简单做出来试试,好像如果比赛的时候这么折腾大概肯定不行;我的这个想法是解耦arm嵌入式linux开发板与硬件(相机和uart串口)交互的代码,从而能在x86主机上用模拟的相机和uart串口调试程序验证算法,免去了在低性能arm嵌入式linux开发板上直接开发程序的卡顿和开发生态不好的折磨,并且更方便接入ci测试快速迭代优化算法.后续可以加入支持交叉编译arm target的补丁(未完成,不包含在此PR中),形成完整闭合工作流(**x86主机加模拟相机(.mp4文件输入)和模拟串口输入输出(直接接入printf等)开发算法处理.mp4图像帧[接入ci保证算法可靠]-->算法稳定后-->[取消模拟相机和uart的编译选项]交叉编译部署bin文件到arm开发板**):)